### PR TITLE
Question service interval

### DIFF
--- a/configure-git-user-settings.ps1
+++ b/configure-git-user-settings.ps1
@@ -1,0 +1,32 @@
+﻿$setting = @{
+    "email" = "frank.thompson.jr@gmail.com"
+    "name" = "Frank Thompson"
+}
+$locations = @(
+    "C:\_g\leads-reader",
+    "C:\_g\lui\fwthompsonjr\leads-ui",
+    "C:\_d\lead-old"
+);
+$readOnly = $true
+$currentLc = Get-Location
+try
+{
+    $uemail = $setting.email;
+    $uname = $setting.name;
+
+    foreach( $loc in $locations )
+    {
+        Write-Output "User settings for folder $loc";
+        Set-Location $loc
+        if ($readOnly -eq $false )
+        {
+            git config user.email $uemail
+            git config user.name $uname
+        }
+        git config --get user.email 
+        git config --get user.name
+    }
+}
+finally {
+    Set-Location $currentLc
+}

--- a/src/worker/RELEASE-NOTES.txt
+++ b/src/worker/RELEASE-NOTES.txt
@@ -1,6 +1,8 @@
 
       legallead.reader.service
       - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - 
+      : 3.2.6 - 2024-07-20 - Configure timer defaults per service read iterations.
+      : 3.2.5 - 2024-07-19 - Fetch records preventing concurrent processing.
       : 3.2.4 - 2024-07-06 - Added new county search processes.
       : 3.2.3 - 2024-06-29 - Packaging dotnet runtime.
       : 3.2.2 - 2024-06-24 - Adding process to expose queue status.

--- a/src/worker/legallead.reader.service.csproj
+++ b/src/worker/legallead.reader.service.csproj
@@ -1,12 +1,12 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Worker">
+<Project Sdk="Microsoft.NET.Sdk.Worker">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <RuntimeIdentifiers>win-x64</RuntimeIdentifiers>
     <Nullable>enable</Nullable>
     <ImplicitUsings>enable</ImplicitUsings>
     <UserSecretsId>dotnet-component-906e3ed5-0a9e-42a3-a3be-cd6406812100</UserSecretsId>
-    <AssemblyVersion>3.2.4</AssemblyVersion>
-    <FileVersion>3.2.4</FileVersion>
+    <AssemblyVersion>3.2.6</AssemblyVersion>
+    <FileVersion>3.2.6</FileVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <Description>Windows process to perform local user based searches for legal leads components.</Description>

--- a/src/worker/utility/ServiceExtensions.cs
+++ b/src/worker/utility/ServiceExtensions.cs
@@ -22,8 +22,8 @@ namespace legallead.reader.service.utility
             var setting = new BackgroundServiceSettings
             {
                 Enabled = configuration?.GetValue<bool>("BackgroundServices:Enabled") ?? true,
-                Delay = configuration?.GetValue<int>("BackgroundServices:Delay") ?? 45,
-                Interval = configuration?.GetValue<int>("BackgroundServices:Interval") ?? 10
+                Delay = configuration?.GetValue<int>("BackgroundServices:Delay") ?? 15,
+                Interval = configuration?.GetValue<int>("BackgroundServices:Interval") ?? 2
             };
             services.AddSingleton<IBackgroundServiceSettings>(x => setting);
             services.AddSingleton<IDapperCommand, DapperExecutor>();

--- a/src/worker/z-app-version.json
+++ b/src/worker/z-app-version.json
@@ -1,5 +1,10 @@
 [
   {
+    "id": "3.2.6",
+    "description": "Configure timer defaults per service read iterations.",
+    "date": "2024-07-20"
+  },
+  {
     "id": "3.2.5",
     "description": "Fetch records preventing concurrent processing.",
     "date": "2024-07-19"


### PR DESCRIPTION
Problem:
The amount of time that a user waits for a search to begin processing is uncertain, need to research the background processor to determine the timing associated and confirm that service recycles at an appropriate interval.

Fix:
- Configure timer defaults per service read iterations.
- Initial delay := 15 seconds
- Refresh interval := 2 mins

Closes #40 